### PR TITLE
fixed ability to register any canister as source

### DIFF
--- a/docs/modoc/SharedStreamManager.md
+++ b/docs/modoc/SharedStreamManager.md
@@ -53,9 +53,9 @@ principals and id-s of registered cross-canister stream sources
 func prioritySourceCanisters() : Vec.Vector<(Principal, Nat)>
 ```
 
-principals of cross-canister stream surces with the priority. The priority value tells the caller
-with what probability he should chose that canister for their needs. In future this value will be used for
-load balancing calls, for now it returns either 0 or 1. Zero value means that stream is closed it the canister should not be used
+principals of cross-canister stream sources with the priority. The priority value tells the caller with what probability they should 
+chose that canister for their needs (sum of all values is not normalized). In the future this value will be used for
+load balancing, for now it returns either 0 or 1. Zero value means that stream is closed and the canister should not be used
 
 
 ### Function `getStream`

--- a/docs/modoc/SharedStreamManager.md
+++ b/docs/modoc/SharedStreamManager.md
@@ -34,7 +34,7 @@ A manager, which is responsible for handling multiple incoming streams. Incapsul
 
 ### Function `sourceCanisters`
 ``` motoko
-func sourceCanisters() : Vec.Vector<Principal>
+func sourceCanisters() : [Principal]
 ```
 
 principals of registered cross-canister stream sources
@@ -42,7 +42,7 @@ principals of registered cross-canister stream sources
 
 ### Function `canisterStreams`
 ``` motoko
-func canisterStreams() : Vec.Vector<(Principal, ?Nat)>
+func canisterStreams() : [(Principal, ?Nat)]
 ```
 
 principals and id-s of registered cross-canister stream sources
@@ -50,10 +50,10 @@ principals and id-s of registered cross-canister stream sources
 
 ### Function `prioritySourceCanisters`
 ``` motoko
-func prioritySourceCanisters() : Vec.Vector<(Principal, Nat)>
+func prioritySourceCanisters() : [(Principal, Nat)]
 ```
 
-principals of cross-canister stream sources with the priority. The priority value tells the caller with what probability they should 
+principals of cross-canister stream sources with the priority. The priority value tells the caller with what probability they should
 chose that canister for their needs (sum of all values is not normalized). In the future this value will be used for
 load balancing, for now it returns either 0 or 1. Zero value means that stream is closed and the canister should not be used
 

--- a/docs/modoc/SharedStreamManager.md
+++ b/docs/modoc/SharedStreamManager.md
@@ -48,6 +48,16 @@ func canisterStreams() : Vec.Vector<(Principal, ?Nat)>
 principals and id-s of registered cross-canister stream sources
 
 
+### Function `prioritySourceCanisters`
+``` motoko
+func prioritySourceCanisters() : Vec.Vector<(Principal, Nat)>
+```
+
+principals of cross-canister stream surces with the priority. The priority value tells the caller
+with what probability he should chose that canister for their needs. In future this value will be used for
+load balancing calls, for now it returns either 0 or 1. Zero value means that stream is closed it the canister should not be used
+
+
 ### Function `getStream`
 ``` motoko
 func getStream(id : Nat) : ?StreamInfo<T>

--- a/docs/modoc/SharedStreamManager.md
+++ b/docs/modoc/SharedStreamManager.md
@@ -40,6 +40,14 @@ func sourceCanisters() : Vec.Vector<Principal>
 principals of registered cross-canister stream sources
 
 
+### Function `canisterStreams`
+``` motoko
+func canisterStreams() : Vec.Vector<(Principal, ?Nat)>
+```
+
+principals and id-s of registered cross-canister stream sources
+
+
 ### Function `getStream`
 ``` motoko
 func getStream(id : Nat) : ?StreamInfo<T>

--- a/src/SharedStreamManager.mo
+++ b/src/SharedStreamManager.mo
@@ -139,6 +139,7 @@ module {
     };
 
     public func unshare(d : StableData) {
+      Vec.clear(streams_);
       for ((info, id) in Vec.items(d.0)) {
         Vec.add(
           streams_,

--- a/src/SharedStreamManager.mo
+++ b/src/SharedStreamManager.mo
@@ -58,9 +58,9 @@ module {
     /// principals and id-s of registered cross-canister stream sources
     public func canisterStreams() : Vec.Vector<(Principal, ?Nat)> = Vec.fromIter(List.toIter(sourceCanistersStreamMap));
 
-    /// principals of cross-canister stream surces with the priority. The priority value tells the caller
-    /// with what probability he should chose that canister for their needs. In future this value will be used for
-    /// load balancing calls, for now it returns either 0 or 1. Zero value means that stream is closed it the canister should not be used
+    /// principals of cross-canister stream sources with the priority. The priority value tells the caller with what probability they should 
+    /// chose that canister for their needs (sum of all values is not normalized). In the future this value will be used for
+    /// load balancing, for now it returns either 0 or 1. Zero value means that stream is closed and the canister should not be used
     public func prioritySourceCanisters() : Vec.Vector<(Principal, Nat)> = Vec.fromIter(
       Iter.map<(Principal, ?Nat), (Principal, Nat)>(
         List.toIter(sourceCanistersStreamMap),

--- a/src/SharedStreamManager.mo
+++ b/src/SharedStreamManager.mo
@@ -55,15 +55,15 @@ module {
     );
 
     /// principals of registered cross-canister stream sources
-    public func sourceCanisters() : Vec.Vector<Principal> = Vec.fromIter(Iter.map<(Principal, ?Nat), Principal>(List.toIter(sourceCanistersStreamMap), func(p, n) = p));
+    public func sourceCanisters() : [Principal] = Iter.toArray(Iter.map<(Principal, ?Nat), Principal>(List.toIter(sourceCanistersStreamMap), func(p, n) = p));
 
     /// principals and id-s of registered cross-canister stream sources
-    public func canisterStreams() : Vec.Vector<(Principal, ?Nat)> = Vec.fromIter(List.toIter(sourceCanistersStreamMap));
+    public func canisterStreams() : [(Principal, ?Nat)] = Iter.toArray(List.toIter(sourceCanistersStreamMap));
 
     /// principals of cross-canister stream sources with the priority. The priority value tells the caller with what probability they should
     /// chose that canister for their needs (sum of all values is not normalized). In the future this value will be used for
     /// load balancing, for now it returns either 0 or 1. Zero value means that stream is closed and the canister should not be used
-    public func prioritySourceCanisters() : Vec.Vector<(Principal, Nat)> = Vec.fromIter(
+    public func prioritySourceCanisters() : [(Principal, Nat)] = Iter.toArray(
       Iter.map<(Principal, ?Nat), (Principal, Nat)>(
         List.toIter(sourceCanistersStreamMap),
         func(p, n) = (


### PR DESCRIPTION
fixed ability to register any canister as source to shared stream manager; 
added ability to fetch source canister principals alongside with appropriate stream id-s