### PR TITLE
Added ability to set max stream length to manager's stream receivers

### DIFF
--- a/docs/modoc/SharedStreamManager.md
+++ b/docs/modoc/SharedStreamManager.md
@@ -33,7 +33,7 @@ type Callbacks<T> = { onReceiverRegistered : (streamId : Nat, receiver : Receive
 ## Class `StreamsManager<T>`
 
 ``` motoko
-class StreamsManager<T>(streamsPerSourceCanister : Nat, itemCallback : (streamId : Nat, item : ?T, index : Nat) -> Bool)
+class StreamsManager<T>(streamsPerSourceCanister : Nat, itemCallback : (streamId : Nat, item : ?T, index : Nat) -> Bool, maxStreamLength : ?Nat)
 ```
 
 A manager, which is responsible for handling multiple incoming streams. Incapsulates a set of stream receivers


### PR DESCRIPTION
This PR adds mandatory contructor argument to SharedStreamManager to set max stream length to all the receivers. It does not have ability to change this value without upgrading canister