### PR TITLE
Concurrency tests

### DIFF
--- a/src/TokenHandler/ICRC1.mo
+++ b/src/TokenHandler/ICRC1.mo
@@ -25,7 +25,9 @@ module {
 
   public type ICRC1Ledger = actor {
     icrc1_fee : query () -> async (Nat);
-    icrc1_balance_of : query (Account) -> async (Nat);
+    // We do not declare icrc1_balance_of as query.
+    // TODO: Is this ok to leave it like that?
+    icrc1_balance_of : (Account) -> async (Nat);
     icrc1_transfer : (TransferArgs) -> async ({
       #Ok : Nat;
       #Err : TransferError;

--- a/test/handler/MockLedger.mo
+++ b/test/handler/MockLedger.mo
@@ -39,7 +39,7 @@ actor class MockLedger(
     init.transfer_fee;
   };
 
-  public query func icrc1_balance_of(account : Account) : async Nat {
+  public func icrc1_balance_of(account : Account) : async Nat {
     getBalance(account.subaccount);
   };
 

--- a/test/handler/async.test.mo
+++ b/test/handler/async.test.mo
@@ -1,6 +1,5 @@
 import Principal "mo:base/Principal";
-import { print; trap } "mo:base/Debug";
-import Error "mo:base/Error";
+import { print } "mo:base/Debug";
 import TokenHandler "../../src/TokenHandler";
 
 type Account = { owner : Principal; subaccount : ?Subaccount };
@@ -29,19 +28,30 @@ type TransferResponse = {
 };
 
 actor class MockLedger() { 
-  var fee = 0;
-  var balance = 0;
+  var fee : Nat = 0;
+  var balance : Nat = 0;
+  var balance_lock : Bool = false;
   var response : TransferResponse = #Ok 42;
 
   public query func icrc1_fee() : async Nat { fee };
   public func set_fee(x : Nat) : async () { fee := x };
 
-  public query func icrc1_balance_of(_ : Account) : async Nat { balance };
+  public func icrc1_balance_of(_ : Account) : async Nat { 
+    while (balance_lock) {
+      await async {}
+    };
+    balance
+  };
+
   public func set_balance(x : Nat) : async () { balance := x };
+  public func release_balance() : async () { balance_lock := false };
+  public func lock_balance() : async () { balance_lock := true };
 
   public func icrc1_transfer(_ : TransferArgs) : async TransferResponse { response };
   public func set_response(r : TransferResponse) : async () { response := r };
 };
+
+await async {};
 
 let ledger = await MockLedger();
 let anon_p = Principal.fromBlob("");
@@ -53,6 +63,12 @@ func assert_state(x : (Nat, Nat, Nat)) {
   assert handler.depositedFunds() == x.0;
   assert handler.consolidatedFunds() == x.1;
   assert handler.depositsNumber() == x.2;
+};
+
+func state() {
+  print(debug_show (handler.depositedFunds(),
+  handler.consolidatedFunds(),
+  handler.depositsNumber()));
 };
 
 do {
@@ -90,4 +106,24 @@ do {
   assert_state(0,0,0);
   assert handler.journalLength() == inc(2); // #feeUpdated, #debited
   print("tree lookups = " # debug_show handler.lookups());
+  // increase deposit again
+  await ledger.set_balance(7);
+  assert (await* handler.notify(user1)) == ?(7,1); // deposit = 7, credit = 1
+  assert_state(7,0,1);
+  assert handler.journalLength() == inc(2); // #newDeposit, #credited
+  // increase fee while notify is underway (and item still in queue)
+  await ledger.lock_balance();
+  let f = async { await* handler.notify(user1) }; // would return ?(0,1) at old fee
+  await ledger.set_fee(10);
+  ignore await* handler.updateFee();
+  assert handler.journalLength() == inc(1); // #feeUpdated, not #debited because user1 is locked
+  assert_state(7,0,1); // state still unchanged
+  await ledger.release_balance(); // let notify return
+  assert (await f) == ?(0,0); // deposit <= fee
+  assert_state(0,0,0); // state should have changed
+  assert handler.journalLength() == inc(1); // should be #debited
+  // TODO
+  // The above test was for the scenario: old_fee < previous = latest <= new_fee
+  // We also need to test:
+  // old_fee < previous <= new_fee < latest
 };

--- a/test/handler/async.test.mo
+++ b/test/handler/async.test.mo
@@ -115,26 +115,28 @@ do {
   // scenario 1: old_fee < previous = latest <= new_fee
   // this means no new deposit has happened (latest = previous) 
   await ledger.lock_balance();
-  let f = async { await* handler.notify(user1) }; // would return ?(0,1) at old fee
+  let f1 = async { await* handler.notify(user1) }; // would return ?(0,1) at old fee
   await ledger.set_fee(10);
   ignore await* handler.updateFee();
   assert handler.journalLength() == inc(1); // #feeUpdated, not #debited because user1 is locked
   assert_state(7,0,1); // state still unchanged
   await ledger.release_balance(); // let notify return
-  assert (await f) == ?(0,0); // deposit <= fee
+  assert (await f1) == ?(0,0); // deposit <= new fee
   assert_state(0,0,0); // state has changed
   assert handler.journalLength() == inc(1); // #debited
   // increase fee while notify is underway (and item still in queue)
   // scenario 2: old_fee < previous <= new_fee < latest
+  /*
   await ledger.set_balance(20);
   await ledger.lock_balance();
-  let f = async { await* handler.notify(user1) }; // would return ?(0,1) at old fee
+  let f2 = async { await* handler.notify(user1) }; // would return ?(13,14) at old fee
   await ledger.set_fee(10);
   ignore await* handler.updateFee();
   assert handler.journalLength() == inc(1); // #feeUpdated, not #debited because user1 is locked
   assert_state(7,0,1); // state still unchanged
   await ledger.release_balance(); // let notify return
-  assert (await f) == ?(13,10); // credit = latest - new_fee
+  assert (await f2) == ?(13,10); // credit = latest - new_fee
   assert_state(20,0,1); // state should have changed
   assert handler.journalLength() == inc(2); // #newDeposit, #credited
+  */
 };


### PR DESCRIPTION
We add test for when multiple calls to or from the TokenHandler happen concurrently.

For example: a fee change while a notify() call is underway.