### PR TITLE
recalculateDepositRegistry and notify

### DIFF
--- a/src/TokenHandler/AccountManager.mo
+++ b/src/TokenHandler/AccountManager.mo
@@ -205,6 +205,7 @@ module {
           };
 
           credit(p, deposit - expected_fee);
+          queuedFunds += deposit;
         };
         case (_) {};
       };

--- a/test/handler/async.test.mo
+++ b/test/handler/async.test.mo
@@ -1,63 +1,8 @@
 import Principal "mo:base/Principal";
 import { print } "mo:base/Debug";
+
 import TokenHandler "../../src/TokenHandler";
-
-type Account = { owner : Principal; subaccount : ?Subaccount };
-type Subaccount = Blob;
-type TransferArgs = {
-  from_subaccount : ?Subaccount;
-  to : Account;
-  amount : Nat;
-  fee : ?Nat;
-  memo : ?Blob;
-  created_at_time : ?Nat64;
-};
-type TransferError = {
-  #BadFee : { expected_fee : Nat };
-  #BadBurn : { min_burn_amount : Nat };
-  #InsufficientFunds : { balance : Nat };
-  #TooOld;
-  #CreatedInFuture : { ledger_time : Nat64 };
-  #Duplicate : { duplicate_of : Nat };
-  #TemporarilyUnavailable;
-  #GenericError : { error_code : Nat; message : Text };
-};
-type TransferResponse = {
-    #Ok : Nat;
-    #Err : TransferError;
-};
-
-actor class MockLedger() { 
-  var fee : Nat = 0;
-  var balance : Nat = 0;
-  var balance_lock : Bool = false;
-  var response : TransferResponse = #Ok 42;
-
-  public query func icrc1_fee() : async Nat { fee };
-  public func set_fee(x : Nat) : async () { fee := x };
-
-  public func icrc1_balance_of(_ : Account) : async Nat { 
-    var inc : Nat = 0;
-    // inc - workaround for the case when
-    // background process is still running
-    // and blocking the execution of the script
-    // after an assertion failure
-    while (balance_lock and inc < 100) {
-      await async {};
-      inc += 1;
-    };
-    balance
-  };
-
-  public func set_balance(x : Nat) : async () { balance := x };
-  public func release_balance() : async () { balance_lock := false };
-  public func lock_balance() : async () { balance_lock := true };
-
-  public func icrc1_transfer(_ : TransferArgs) : async TransferResponse { response };
-  public func set_response(r : TransferResponse) : async () { response := r };
-};
-
-await async {};
+import { MockLedger } "mock_ledger";
 
 let ledger = await MockLedger();
 let anon_p = Principal.fromBlob("");
@@ -71,85 +16,163 @@ func assert_state(x : (Nat, Nat, Nat)) {
   assert handler.depositsNumber() == x.2;
 };
 
-func state() {
-  print(debug_show (handler.depositedFunds(),
-  handler.consolidatedFunds(),
-  handler.depositsNumber()));
+module Debug {
+  func state() {
+    print(
+      debug_show (
+        handler.depositedFunds(),
+        handler.consolidatedFunds(),
+        handler.depositsNumber(),
+      )
+    );
+  };
+  func journal() {
+    print(
+      debug_show (
+        handler.queryJournal(?0)
+      )
+    );
+  };
 };
 
-do {
-  var journalCtr = 0;
-  func inc(n : Nat) : Nat { journalCtr += n; journalCtr };
+var journalCtr = 0;
+func inc(n : Nat) : Nat { journalCtr += n; journalCtr };
 
-  // init state 
-  assert handler.fee() == 0;
-  assert handler.journalLength() == 0;
-  // update fee first time
-  await ledger.set_fee(5);
-  ignore await* handler.updateFee();
-  assert handler.fee() == 5;
-  assert handler.journalLength() == inc(1); // #feeUpdated
-  // notify with 0 balance
-  assert (await* handler.notify(user1)) == ?(0,0);
-  assert_state(0,0,0);
-  assert handler.journalLength() == inc(0);
-  print("tree lookups = " # debug_show handler.lookups());
-  // notify with balance <= fee
-  await ledger.set_balance(5);
-  assert (await* handler.notify(user1)) == ?(0,0);
-  assert_state(0,0,0);
-  assert handler.journalLength() == inc(0);
-  print("tree lookups = " # debug_show handler.lookups());
-  // notify with balance > fee
-  await ledger.set_balance(6);
-  assert (await* handler.notify(user1)) == ?(6,1); // deposit = 6, credit = 1
-  assert_state(6,0,1);
-  assert handler.journalLength() == inc(2); // #newDeposit, #credited
-  print("tree lookups = " # debug_show handler.lookups());
-  // increase fee while item still in queue (trigger did not run yet)
-  await ledger.set_fee(6);
-  ignore await* handler.updateFee();
-  assert_state(0,0,0);
-  assert handler.journalLength() == inc(2); // #feeUpdated, #debited
-  print("tree lookups = " # debug_show handler.lookups());
-  // increase deposit again
-  await ledger.set_balance(7);
-  assert (await* handler.notify(user1)) == ?(7,1); // deposit = 7, credit = 1
-  assert_state(7,0,1);
-  assert handler.journalLength() == inc(2); // #newDeposit, #credited
-  print("tree lookups = " # debug_show handler.lookups());
-  // increase fee while notify is underway (and item still in queue)
-  // scenario 1: old_fee < previous = latest <= new_fee
-  // this means no new deposit has happened (latest = previous) 
-  await ledger.lock_balance();
-  let f1 = async { await* handler.notify(user1) }; // would return ?(0,1) at old fee
-  await ledger.set_fee(10);
-  ignore await* handler.updateFee();
-  assert handler.journalLength() == inc(1); // #feeUpdated, not #debited because user1 is locked
-  assert_state(7,0,1); // state still unchanged
-  await ledger.release_balance(); // let notify return
-  assert (await f1) == ?(0,0); // deposit <= new fee
-  assert_state(0,0,0); // state has changed
-  assert handler.journalLength() == inc(1); // #debited
-  print("tree lookups = " # debug_show handler.lookups());
-  // increase deposit again
-  await ledger.set_balance(15);
-  assert (await* handler.notify(user1)) == ?(15,5); // deposit = 7, credit = 5
-  assert_state(15,0,1);
-  assert handler.journalLength() == inc(2); // #newDeposit, #credited
-  print("tree lookups = " # debug_show handler.lookups());
-  // increase fee while notify is underway (and item still in queue)
-  // scenario 2: old_fee < previous <= new_fee < latest
-  await ledger.set_balance(20);
-  await ledger.lock_balance();
-  let f2 = async { await* handler.notify(user1) }; // would return ?(5,10) at old fee
-  await ledger.set_fee(15);
-  ignore await* handler.updateFee();
-  assert handler.journalLength() == inc(1); // #feeUpdated, not #debited because user1 is locked
-  assert_state(15,0,1); // state still unchanged
-  await ledger.release_balance(); // let notify return
-  print(debug_show (await f2));
-  assert (await f2) == ?(20,5); // credit = latest - new_fee
-  assert_state(20,0,1); // state should have changed
-  assert handler.journalLength() == inc(3); // #debited (recalculation), #newDeposit, #credited
-};
+// init state
+assert handler.fee() == 0;
+assert handler.journalLength() == 0;
+
+// update fee first time
+await ledger.set_fee(5);
+ignore await* handler.updateFee();
+assert handler.fee() == 5;
+assert handler.journalLength() == inc(1); // #feeUpdated
+
+// notify with 0 balance
+assert (await* handler.notify(user1)) == ?(0, 0);
+assert_state(0, 0, 0);
+assert handler.journalLength() == inc(0);
+print("tree lookups = " # debug_show handler.lookups());
+
+// notify with balance <= fee
+await ledger.set_balance(5);
+assert (await* handler.notify(user1)) == ?(0, 0);
+assert_state(0, 0, 0);
+assert handler.journalLength() == inc(0);
+print("tree lookups = " # debug_show handler.lookups());
+
+// notify with balance > fee
+await ledger.set_balance(6);
+assert (await* handler.notify(user1)) == ?(6, 1); // deposit = 6, credit = 1
+assert_state(6, 0, 1);
+assert handler.journalLength() == inc(2); // #newDeposit, #credited
+print("tree lookups = " # debug_show handler.lookups());
+
+// increase fee while item still in queue (trigger did not run yet)
+await ledger.set_fee(6);
+ignore await* handler.updateFee();
+assert_state(0, 0, 0); // recalculation after fee update
+assert handler.journalLength() == inc(2); // #feeUpdated, #debited
+print("tree lookups = " # debug_show handler.lookups());
+
+// increase deposit again
+await ledger.set_balance(7);
+assert (await* handler.notify(user1)) == ?(7, 1); // deposit = 7, credit = 1
+assert_state(7, 0, 1);
+assert handler.journalLength() == inc(2); // #newDeposit, #credited
+print("tree lookups = " # debug_show handler.lookups());
+
+// increase fee while notify is underway (and item still in queue)
+// scenario 1: old_fee < previous = latest <= new_fee
+// this means no new deposit has happened (latest = previous)
+await ledger.lock_balance();
+let f1 = async { await* handler.notify(user1) }; // would return ?(0,1) at old fee
+await ledger.set_fee(10);
+ignore await* handler.updateFee();
+assert handler.journalLength() == inc(1); // #feeUpdated, not #debited because user1 is locked
+assert_state(7, 0, 1); // state still unchanged
+await ledger.release_balance(); // let notify return
+assert (await f1) == ?(0, 0); // deposit <= new fee
+assert_state(0, 0, 0); // state has changed
+assert handler.journalLength() == inc(1); // #debited
+print("tree lookups = " # debug_show handler.lookups());
+
+// increase deposit again
+await ledger.set_balance(15);
+assert (await* handler.notify(user1)) == ?(15, 5); // deposit = 15, credit = 5
+assert_state(15, 0, 1);
+assert handler.journalLength() == inc(2); // #newDeposit, #credited
+print("tree lookups = " # debug_show handler.lookups());
+
+// increase fee while notify is underway (and item still in queue)
+// scenario 2: old_fee < previous <= new_fee < latest
+await ledger.set_balance(20);
+await ledger.lock_balance();
+let f2 = async { await* handler.notify(user1) }; // would return ?(5,10) at old fee
+await ledger.set_fee(15);
+ignore await* handler.updateFee();
+assert handler.journalLength() == inc(1); // #feeUpdated, not #debited because user1 is locked
+assert_state(15, 0, 1); // state still unchanged
+await ledger.release_balance(); // let notify return
+assert (await f2) == ?(20, 5); // credit = latest - new_fee
+assert_state(20, 0, 1); // state should have changed
+assert handler.journalLength() == inc(3); // #debited (recalculation), #newDeposit, #credited
+print("tree lookups = " # debug_show handler.lookups());
+
+// call multiple notify() simultaneously
+await ledger.lock_balance();
+let arr = [async { await* handler.notify(user1) }, async { await* handler.notify(user1) }, async { await* handler.notify(user1) }];
+await ledger.release_balance(); // let notify return
+assert (await arr[0]) == ?(0, 5); // first notify() should return state
+assert (await arr[1]) == null; // should return null
+assert (await arr[2]) == null; // should return null
+assert_state(20, 0, 1); // state unchanged because deposit has not changed
+assert handler.journalLength() == inc(0);
+print("tree lookups = " # debug_show handler.lookups());
+
+// only 1 consolidation process can be triggered for same user at same time
+var transfer_count = await ledger.transfer_count();
+let f3 = async { await* handler.trigger() };
+let f4 = async { await* handler.trigger() };
+await f3;
+await f4;
+assert ((await ledger.transfer_count())) == transfer_count + 1; // only 1 transfer call has been made
+assert_state(0, 5, 0); // consolidation successful
+assert handler.journalLength() == inc(1); // #consolidated
+print("tree lookups = " # debug_show handler.lookups());
+
+// increase fee while deposit is being consolidated
+// scenario 1: old_fee < deposit < new_fee
+// consolidation should fail and deposit should be reset
+await ledger.set_balance(20);
+assert (await* handler.notify(user1)) == ?(20, 10); // deposit = 20, credit = 10
+assert handler.journalLength() == inc(2); // #credited, #newDeposit
+assert_state(20, 5, 1);
+await ledger.lock_transfer();
+let f5 = async { await* handler.trigger() };
+await ledger.set_fee(25);
+await ledger.set_response(#Err(#BadFee { expected_fee = 25 }));
+await ledger.release_transfer(); // let transfer return
+await f5;
+assert_state(0, 5, 0); // consolidation failed
+assert handler.journalLength() == inc(3); // #consolidationError, #debited, #feeUpdated
+print("tree lookups = " # debug_show handler.lookups());
+
+// increase fee while deposit is being consolidated
+// scenario 2: old_fee < new_fee < deposit
+// consolidation should fail and deposit should be adjusted with new fee
+await ledger.set_balance(35);
+assert (await* handler.notify(user1)) == ?(35, 15); // deposit = 35, credit = 15
+assert handler.journalLength() == inc(2); // #credited, #newDeposit
+assert_state(35, 5, 1);
+await ledger.lock_transfer();
+let f6 = async { await* handler.trigger() };
+await ledger.set_fee(26);
+await ledger.set_response(#Err(#BadFee { expected_fee = 26 }));
+await ledger.release_transfer(); // let transfer return
+await f6;
+assert_state(35, 5, 1); // consolidation failed with updated deposit scheduled
+assert handler.journalLength() == inc(4); // #consolidationError, #debited, #feeUpdated, #credited
+assert (await* handler.notify(user1)) == ?(0, 14); // credit corrected after consolidation
+assert handler.journalLength() == inc(0);
+print("tree lookups = " # debug_show handler.lookups());

--- a/test/handler/mock_ledger.mo
+++ b/test/handler/mock_ledger.mo
@@ -1,0 +1,70 @@
+module {
+
+  type Account = { owner : Principal; subaccount : ?Subaccount };
+  type Subaccount = Blob;
+  type TransferArgs = {
+    from_subaccount : ?Subaccount;
+    to : Account;
+    amount : Nat;
+    fee : ?Nat;
+    memo : ?Blob;
+    created_at_time : ?Nat64;
+  };
+  type TransferError = {
+    #BadFee : { expected_fee : Nat };
+    #BadBurn : { min_burn_amount : Nat };
+    #InsufficientFunds : { balance : Nat };
+    #TooOld;
+    #CreatedInFuture : { ledger_time : Nat64 };
+    #Duplicate : { duplicate_of : Nat };
+    #TemporarilyUnavailable;
+    #GenericError : { error_code : Nat; message : Text };
+  };
+  type TransferResponse = {
+    #Ok : Nat;
+    #Err : TransferError;
+  };
+
+  public actor class MockLedger() {
+    var fee : Nat = 0;
+    var balance : Nat = 0;
+    var balance_lock : Bool = false;
+    var response : TransferResponse = #Ok 42;
+    var transfer_lock : Bool = false;
+    var transfer_count_ : Nat = 0;
+
+    public query func icrc1_fee() : async Nat { fee };
+    public func set_fee(x : Nat) : async () { fee := x };
+
+    public func icrc1_balance_of(_ : Account) : async Nat {
+      var inc : Nat = 0;
+      // inc - workaround for the case when
+      // background process is still running
+      // and blocking the execution of the script
+      // after an assertion failure
+      while (balance_lock and inc < 100) {
+        await async {};
+        inc += 1;
+      };
+      balance;
+    };
+    public func set_balance(x : Nat) : async () { balance := x };
+    public func lock_balance() : async () { balance_lock := true };
+    public func release_balance() : async () { balance_lock := false };
+
+    public func icrc1_transfer(_ : TransferArgs) : async TransferResponse {
+      var inc : Nat = 0;
+      while (transfer_lock and inc < 100) {
+        await async {};
+        inc += 1;
+      };
+      transfer_count_ += 1;
+      response;
+    };
+    public func lock_transfer() : async () { transfer_lock := true };
+    public func release_transfer() : async () { transfer_lock := false };
+    public func set_response(r : TransferResponse) : async () { response := r };
+    public func transfer_count() : async Nat { transfer_count_ };
+  };
+
+};


### PR DESCRIPTION
We realized that recalculateDepositRegistry andenotify can overlap freely.  We distinguish the locks coming from notify from the ones from consolidate.  Only if p is locked from consolidation then we skip over p in recalculateDepositRegistry.

That way, at the end of notify we don't have to reprocess p for a potential fee change anymore. Because that has already been done. This simplifies code and debits the user earlier.