### PR TITLE
Various renaming

### DIFF
--- a/src/TokenHandler/CreditRegistry.mo
+++ b/src/TokenHandler/CreditRegistry.mo
@@ -4,75 +4,96 @@ import IntMap "IntMap";
 module {
   public type StableData = ([(Principal, Int)], Int);
 
+  public type Account = { #pool; #user : Principal };
+
   public type LogEvent = {
     #credited : Nat;
     #debited : Nat;
-    #issuerCredited : Nat;
-    #issuerDebited : Nat;
+    #issued : Int;
+    #burned : Nat;
   };
 
   /// Tracks credited funds (usable balance) associated with each principal.
-  public class CreditRegistry(ownPrincipal : Principal, log : (Principal, LogEvent) -> ()) {
+  public class CreditRegistry(log : (Principal, LogEvent) -> ()) {
     var map = IntMap.Map<Principal>(Principal.compare);
+    var pool_ : Int = 0;
 
     var issuer_ : Int = 0;
 
     /// Retrieves the total credited funds in the credit registry.
-    public func creditTotal() : Int = map.sum();
+    public func totalBalance() : Int = map.sum() + pool_;
+
+    /// Retrieves the total credited funds in the pool.
+    public func poolBalance() : Int = pool_;
 
     /// Gets the current credit amount associated with a specific principal.
-    public func get(p : Principal) : Int = map.get(p);
+    public func userBalance(p : Principal) : Int = map.get(p);
 
-    /// Gets the current credit amount of the issuer account.
-    public func issuer() : Int = issuer_;
-
-    /// Deducts amount from the issuer account credit.
-    public func debitIssuer(amount : Nat) {
-      issuer_ -= amount;
-      log(ownPrincipal, #issuerDebited(amount));
-    };
-
-    /// Increases the current issuer account credit.
-    public func creditIssuer(amount : Nat) {
-      issuer_ += amount;
-      log(ownPrincipal, #issuerCredited(amount));
-    };
-
-    /// Deducts amount from P’s credit.
-    /// With checking the availability of sufficient funds in the P's account.
-    public func debitStrict(p : Principal, amount : Nat) : Bool {
-      let res = map.addIf(p, -amount, func x = x >= amount);
-      if (res) {
-        creditIssuer(amount);
-        log(p, #debited(amount));
+    // transfer is checked, doesn't allow balances to go negative
+    func transfer(from : Account, to : Account or { #burn }, amount : Nat) : Bool {
+      switch (from) {
+        case (#pool) {
+          if (pool_ < amount) return false;
+          pool_ -= amount;
+        };
+        case (#user p) {
+          map.addIf(p, -amount, func x = x >= amount)
+          |> (if (not _) return false);
+        };
       };
-      res;
-    };
-
-    /// Adds amount to P’s credit.
-    /// With checking the availability of sufficient funds in the issuer account.
-    public func creditStrict(p : Principal, amount : Nat) : Bool {
-      let res = issuer_ >= amount;
-      if (res) {
-        map.add(p, amount);
-        debitIssuer(amount);
-        log(p, #credited(amount));
+      switch (to) {
+        case (#pool) {
+          pool_ += amount;
+        };
+        case (#user p) {
+          map.add(p, amount);
+        };
+        case (#burn) {
+        };
       };
-      res;
+      true
     };
 
-    /// Deducts amount from P’s credit.
-    /// Without checking the availability of sufficient funds.
-    public func debit(p : Principal, amount : Nat) {
-      map.add(p, -amount);
-      log(p, #debited(amount));
+    // The creditUser/debitUser functions transfer credit from the
+    // user to/from the pool.
+    public func creditUser(p : Principal, amount : Nat) : Bool {
+      let success = transfer(#pool, #user p, amount);
+      if (success) log(p, #credited(amount));
+      success;
     };
 
-    /// Increases the credit amount associated with a specific principal.
-    /// Without checking the availability of sufficient funds.
-    public func credit(p : Principal, amount : Nat) {
-      map.add(p, amount);
-      log(p, #credited(amount));
+    public func debitUser(p : Principal, amount : Nat) : Bool {
+      let success = transfer(#user p, #pool, amount);
+      if (success) log(p, #debited(amount));
+      success;
+    };
+
+    // Issue credit to any user (or burn from user)
+    // This is called on deposits or withdrawals
+    // No check is performed, balances can go negative as a result
+    public func issue(account : Account, amount : Int) {
+      switch (account) {
+        case (#pool) {
+          pool_ += amount;
+          log(Principal.fromBlob(""), #issued(amount));
+        };
+        case (#user p) {
+          map.add(p, amount);
+          log(p, #issued(amount));
+        };
+      };
+    };
+
+    // Burn credit from the pool
+    // This is called on withdrawals
+    // A check is performed, pool balance can not go negative
+    public func burn(account : Account, amount : Nat) : Bool {
+      let success = transfer(account, #burn, amount);
+      if (success) switch (account) {
+        case (#pool) log(Principal.fromBlob(""), #burned(amount));
+        case (#user p) log(p, #burned(amount));
+      };
+      success;
     };
 
     /// Serializes the credit registry data.

--- a/src/TokenHandler/lib.mo
+++ b/src/TokenHandler/lib.mo
@@ -2,6 +2,8 @@ import Principal "mo:base/Principal";
 import Int "mo:base/Int";
 import Text "mo:base/Text";
 import Nat "mo:base/Nat";
+import Result "mo:base/Result";
+import Debug "mo:base/Debug";
 
 import Mapping "Mapping";
 import ICRC1 "ICRC1";
@@ -46,7 +48,7 @@ module {
 
     // Pass through the lookup counter from depositRegistry
     // TODO: Remove later
-    public func lookups() : Nat = accountManager.lookups();
+    public func lookups_() : Nat = accountManager.lookups();
 
     /// If some unexpected error happened, this flag turns true and handler stops doing anything until recreated.
     var isFrozen_ : Bool = false;
@@ -65,7 +67,7 @@ module {
     var journal = Journal.Journal(journalCapacity);
 
     /// Tracks credited funds (usable balance) associated with each principal.
-    let creditRegistry = CreditRegistry.CreditRegistry(ownPrincipal, journal.push);
+    let creditRegistry = CreditRegistry.CreditRegistry(journal.push);
 
     /// Manages accounts and funds for users.
     /// Handles deposit, withdrawal, and consolidation operations.
@@ -75,8 +77,7 @@ module {
       journal.push,
       initialFee,
       freezeTokenHandler,
-      creditRegistry.credit,
-      creditRegistry.debit,
+      func (p : Principal, x : Int) { creditRegistry.issue(#user p, x) },
     );
 
     /// Returns the ledger fee.
@@ -106,11 +107,6 @@ module {
       await* accountManager.fetchFee();
     };
 
-    /// Returns a user's current credit
-    public func getCredit(p : Principal) : Int {
-      creditRegistry.get(p);
-    };
-
     /// Returns a user's last know (= tracked) deposit
     /// Null means the principal is locked, hence no value is available.
     public func trackedDeposit(p : Principal) : ?Nat = accountManager.getDeposit(p);
@@ -136,6 +132,7 @@ module {
       };
       credit : {
         total : Int;
+        pool : Int;
       };
       users : {
         queued : Nat;
@@ -153,7 +150,8 @@ module {
         withdrawn = accountManager.totalWithdrawn();
       };
       credit = {
-        total = creditRegistry.creditTotal();
+        total = creditRegistry.totalBalance();
+        pool = creditRegistry.poolBalance();
       };
       users = {
         queued = accountManager.depositsNumber();
@@ -164,39 +162,31 @@ module {
     public func journalLength() : Nat = journal.length();
 
     /// Gets the current credit amount associated with a specific principal.
-    public func balance(p : Principal) : Int = creditRegistry.get(p);
+    public func userCredit(p : Principal) : Int = creditRegistry.userBalance(p);
 
-    /// Gets the current credit amount of the issuer account.
-    public func issuer() : Int = creditRegistry.issuer();
-
-    /// Deducts amount from the issuer account credit.
-    public func debitIssuer(amount : Nat) = creditRegistry.debitIssuer(amount);
-
-    /// Increases the current issuer account credit.
-    public func creditIssuer(amount : Nat) = creditRegistry.creditIssuer(amount);
-
-    /// Deducts amount from P’s usable balance.
-    /// With checking the availability of sufficient funds.
-    public func debitStrict(p : Principal, amount : Nat) : Bool = creditRegistry.debitStrict(p, amount);
+    /// Gets the current credit amount in the pool.
+    public func poolCredit() : Int = creditRegistry.poolBalance();
 
     /// Adds amount to P’s credit.
-    /// With checking the availability of sufficient funds in the issuer account.
-    public func creditStrict(p : Principal, amount : Nat) : Bool = creditRegistry.creditStrict(p, amount);
+    /// With checking the availability of sufficient funds.
+    public func creditUser(p : Principal, amount : Nat) : Bool = creditRegistry.creditUser(p, amount);
 
-    /// Deducts amount from P’s usable balance.
-    /// Without checking the availability of sufficient funds.
-    public func debit(p : Principal, amount : Nat) = creditRegistry.debit(p, amount);
+    /// Deducts amount from P’s credit.
+    /// With checking the availability of sufficient funds in the pool.
+    public func debitUser(p : Principal, amount : Nat) : Bool = creditRegistry.debitUser(p, amount);
 
-    /// Increases the credit amount associated with a specific principal
-    /// (the credit is created out of thin air).
-    public func credit(p : Principal, amount : Nat) = creditRegistry.credit(p, amount);
+    // For debug and testing purposes only.
+    // Issue credit directly to a principal or burn from a principal.
+    // A negative amount means burn.
+    // Without checking the availability of sufficient funds.
+    public func issue_(account : CreditRegistry.Account, amount : Int) = creditRegistry.issue(account, amount);
 
     /// Notifies of a deposit and schedules consolidation process.
     /// Returns the newly detected deposit and credit funds if successful, otherwise null.
     public func notify(p : Principal) : async* ?(Nat, Int) {
       if isFrozen_ return null;
       let ?depositDelta = await* accountManager.notify(p) else return null;
-      ?(depositDelta, creditRegistry.get(p));
+      ?(depositDelta, creditRegistry.userBalance(p));
     };
 
     public func depositFromAllowance(account : ICRC1.Account, amount : Nat) : async* AccountManager.DepositFromAllowanceResponse {
@@ -211,24 +201,37 @@ module {
 
     /// Initiates a withdrawal by transferring tokens to another account.
     /// Returns ICRC1 transaction index and amount of transferred tokens (fee excluded).
-    public func withdraw(to : ICRC1.Account, amount : Nat) : async* AccountManager.WithdrawResponse {
-      await* accountManager.withdraw(to, amount);
+    public func withdrawFromPool(to : ICRC1.Account, amount : Nat) : async* AccountManager.WithdrawResponse {
+      // try to burn from pool
+      Debug.print("pool balance: " # debug_show creditRegistry.poolBalance());
+      Debug.print("burn from pool: " # debug_show amount);
+      let success = creditRegistry.burn(#pool, amount);
+      Debug.print("success: " # debug_show success);
+      if (not success) return #err(#InsufficientCredit);
+      Debug.print("burned");
+      let result = await* accountManager.withdraw(to, amount);
+      if (Result.isErr(result)) {
+        // re-issue credit if unsuccessful
+        creditRegistry.issue(#pool, amount);
+      };
+      result;
     };
 
     /// Initiates a withdrawal by transferring tokens to another account.
     /// Returns ICRC1 transaction index and amount of transferred tokens (fee excluded).
-    /// At the same time, it reduces the user's credit. Accordingly, amount < credit should be satisfied.
+    /// At the same time, it reduces the user's credit. Accordingly, amount <= credit should be satisfied.
     public func withdrawFromCredit(p : Principal, to : ICRC1.Account, amount : Nat) : async* AccountManager.WithdrawResponse {
-      if (amount > creditRegistry.get(p)) {
+      // try to burn from pool
+      creditRegistry.burn(#user p, amount)
+      |> (if (not _) {
         let err = #InsufficientCredit;
         journal.push(ownPrincipal, #withdrawalError(err));
         return #err(err);
-      };
+      });
       let result = await* accountManager.withdraw(to, amount);
-      switch (result) {
-        // sync credit after successful withdrawal
-        case (#ok(_, _)) { creditRegistry.debit(p, amount) };
-        case (_) {};
+      if (Result.isErr(result)) {
+        // re-issue credit if unsuccessful
+        creditRegistry.issue(#user p, amount);
       };
       result;
     };

--- a/test/handler/async3.test.mo
+++ b/test/handler/async3.test.mo
@@ -20,6 +20,7 @@ let user1 = Principal.fromBlob("1");
 let user2 = Principal.fromBlob("2");
 let account = { owner = Principal.fromBlob("o"); subaccount = null };
 let user1_account = { owner = user1; subaccount = null };
+//let account = { owner = Principal.fromBlob("1"); subaccount = null };
 
 func create_inc() : (Nat -> Nat, () -> Nat) {
   var ctr = 0;
@@ -71,35 +72,35 @@ do {
   assert (await* handler.notify(user1)) == ?(0, 0);
   assert state(handler) == (0, 0, 0);
   assert handler.journalLength() == inc(0);
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // notify with balance <= fee
   await ledger.mock.set_balance(5);
   assert (await* handler.notify(user1)) == ?(0, 0);
   assert state(handler) == (0, 0, 0);
   assert handler.journalLength() == inc(0);
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // notify with balance > fee
   await ledger.mock.set_balance(6);
   assert (await* handler.notify(user1)) == ?(6, 1); // deposit = 6, credit = 1
   assert state(handler) == (6, 0, 1);
   assert handler.journalLength() == inc(2); // #newDeposit, #credited
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // increase fee while item still in queue (trigger did not run yet)
   await ledger.mock.set_fee(6);
   ignore await* handler.fetchFee();
   assert state(handler) == (0, 0, 0); // recalculation after fee update
-  assert handler.journalLength() == inc(6); // #feeUpdated, #depositFeeUpdated, #withdrawalFeeUpdated, #debited, #depositMinimumUpdated, #withdrawalMinimumUpdated
-  print("tree lookups = " # debug_show handler.lookups());
+  assert handler.journalLength() == inc(6); // #feeUpdated, #debited, #depositMinimumUpdated, #withdrawalMinimumUpdated, #depositFeeUpdated, #withdrawalFeeUpdated
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // increase deposit again
   await ledger.mock.set_balance(7);
   assert (await* handler.notify(user1)) == ?(7, 1); // deposit = 7, credit = 1
   assert state(handler) == (7, 0, 1);
   assert handler.journalLength() == inc(2); // #newDeposit, #credited
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // increase fee while notify is underway (and item still in queue)
   // scenario 1: old_fee < previous = latest <= new_fee
@@ -114,14 +115,14 @@ do {
   await ledger.mock.release_balance(); // let notify return
   assert (await f1) == ?(0, 0); // deposit <= new fee
   assert handler.journalLength() == inc(0);
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // increase deposit again
   await ledger.mock.set_balance(15);
   assert (await* handler.notify(user1)) == ?(15, 5); // deposit = 15, credit = 5
   assert state(handler) == (15, 0, 1);
   assert handler.journalLength() == inc(2); // #newDeposit, #credited
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // increase fee while notify is underway (and item still in queue)
   // scenario 2: old_fee < previous <= new_fee < latest
@@ -137,7 +138,7 @@ do {
   assert (await f2) == ?(20, 5); // credit = latest - new_fee
   assert state(handler) == (20, 0, 1); // state should have changed
   assert handler.journalLength() == inc(2); // #newDeposit, #credited
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // decrease fee while notify is underway (and item still in queue)
   // new_fee < old_fee < previous == latest
@@ -151,7 +152,7 @@ do {
   await ledger.mock.release_balance(); // let notify return
   assert (await f3) == ?(0, 10); // credit increased
   assert state(handler) == (20, 0, 1); // state unchanged
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // call multiple notify() simultaneously
   // only the first should return state, the rest should not be executed
@@ -165,7 +166,7 @@ do {
   assert (await fut1) == ?(0, 10); // first notify() should return state
   assert state(handler) == (20, 0, 1); // state unchanged because deposit has not changed
   assert handler.journalLength() == inc(0);
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   handler.assertIntegrity();
   assert not handler.isFrozen();
@@ -197,8 +198,9 @@ do {
   await f1;
   assert state(handler) == (0, 0, 0); // consolidation failed with deposit reset
   assert handler.journalLength() == inc(7); // #consolidationError, #debited, #feeUpdated, #depositFeeUpdated, #withdrawalFeeUpdated, #depositMinimumUpdated, #withdrawalMinimumUpdated
-  assert handler.getCredit(user1) == 0; // credit has been corrected after consolidation
-  print("tree lookups = " # debug_show handler.lookups());
+  // TODO assert handler.journalLength() == inc(5); // #consolidationError, #debited, #feeUpdated, #depositMinimumUpdated, #withdrawalMinimumUpdated
+  assert handler.userCredit(user1) == 0; // credit has been corrected after consolidation
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // increase fee while deposit is being consolidated (implicitly)
   // scenario 2: old_fee < new_fee < deposit
@@ -215,8 +217,9 @@ do {
   await f2;
   assert state(handler) == (20, 0, 1); // consolidation failed with updated deposit scheduled
   assert handler.journalLength() == inc(8); // #consolidationError, #debited, #feeUpdated, #depositFeeUpdated, #withdrawalFeeUpdated, #credited, #depositMinimumUpdated, #withdrawalMinimumUpdated
-  assert handler.getCredit(user1) == 5; // credit has been corrected after consolidation
-  print("tree lookups = " # debug_show handler.lookups());
+  // TODO assert handler.journalLength() == inc(6); // #consolidationError, #debited, #feeUpdated, #credited, #depositMinimumUpdated, #withdrawalMinimumUpdated
+  assert handler.userCredit(user1) == 5; // credit has been corrected after consolidation
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // increase fee while deposit is being consolidated (explicitly)
   // scenario 1: old_fee < deposit <= new_fee
@@ -234,8 +237,8 @@ do {
   await f3;
   assert state(handler) == (0, 0, 0); // consolidation failed with deposit reset
   assert handler.journalLength() == inc(2); // #consolidationError, #debited
-  assert handler.getCredit(user1) == 0; // credit has been corrected
-  print("tree lookups = " # debug_show handler.lookups());
+  assert handler.userCredit(user1) == 0; // credit has been corrected
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // increase fee while deposit is being consolidated (explicitly)
   // scenario 2: old_fee < new_fee < deposit
@@ -256,8 +259,8 @@ do {
   await f4;
   assert state(handler) == (20, 0, 1); // consolidation failed with updated deposit scheduled
   assert handler.journalLength() == inc(3); // #consolidationError, #debited, #credited
-  assert handler.getCredit(user1) == 14; // credit has been corrected
-  print("tree lookups = " # debug_show handler.lookups());
+  assert handler.userCredit(user1) == 14; // credit has been corrected
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // only 1 consolidation process can be triggered for same user at same time
   // consolidation with deposit > fee should be successful
@@ -271,8 +274,8 @@ do {
   assert ((await ledger.mock.transfer_count())) == transfer_count + 1; // only 1 transfer call has been made
   assert state(handler) == (0, 14, 0); // consolidation successful
   assert handler.journalLength() == inc(1); // #consolidated
-  assert handler.getCredit(user1) == 14; // credit unchanged
-  print("tree lookups = " # debug_show handler.lookups());
+  assert handler.userCredit(user1) == 14; // credit unchanged
+  print("tree lookups = " # debug_show handler.lookups_());
 
   handler.assertIntegrity();
   assert not handler.isFrozen();
@@ -294,7 +297,7 @@ do {
   assert (await* handler.notify(user1)) == ?(20, 15); // deposit = 20, credit = 15
   assert state(handler) == (20, 0, 1);
   assert handler.journalLength() == inc(2); // #newDeposit, #credited
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // trigger consolidation again
   await ledger.mock.set_response([#Ok 42]);
@@ -302,7 +305,7 @@ do {
   await ledger.mock.set_balance(0);
   assert state(handler) == (0, 15, 0); // consolidation successful
   assert handler.journalLength() == inc(1); // #consolidated
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // withdraw (fee < amount < consolidated_funds)
   // should be successful
@@ -310,23 +313,22 @@ do {
   ignore await* handler.fetchFee();
   assert handler.journalLength() == inc(5); // #feeUpdated, #depositFeeUpdated, #withdrawalFeeUpdated, #depositMinimumUpdated, #withdrawalMinimumUpdated
   await ledger.mock.set_response([#Ok 42]);
-  assert (await* handler.withdraw(account, 5)) == #ok(42, 4);
-  assert handler.journalLength() == inc(1); // #withdraw
-  handler.debit(user1, 5);
+  assert (await* handler.withdrawFromCredit(user1, account, 5)) == #ok(42, 4);
+  assert handler.journalLength() == inc(2); // #burned, #withdraw
   assert state(handler) == (0, 10, 0);
-  assert handler.journalLength() == inc(1); // #debited
 
   // withdraw (amount <= fee_)
   var transfer_count = await ledger.mock.transfer_count();
   await ledger.mock.set_response([#Ok 42]); // transfer call should not be executed anyway
-  assert (await* handler.withdraw(account, 1)) == #err(#TooLowQuantity);
+  assert (await* handler.withdrawFromCredit(user1, account, 1)) == #err(#TooLowQuantity);
   assert (await ledger.mock.transfer_count()) == transfer_count; // no transfer call
   assert state(handler) == (0, 10, 0); // state unchanged
-  assert handler.journalLength() == inc(1); // #withdrawError
+  assert handler.journalLength() == inc(3); // #burned, #withdrawError, #issued
 
   // withdraw (consolidated_funds < amount)
   await ledger.mock.set_response([#Err(#InsufficientFunds({ balance = 10 }))]);
-  assert (await* handler.withdraw(account, 100)) == #err(#InsufficientFunds({ balance = 10 }));
+  // TODO: InsufficientCredit should return current credit balance?
+  assert (await* handler.withdrawFromCredit(user1, account, 100)) == #err(#InsufficientCredit);
   assert state(handler) == (0, 10, 0); // state unchanged
   assert handler.journalLength() == inc(1); // #withdrawError
 
@@ -335,15 +337,15 @@ do {
   // withdraw should fail and then retry successfully, fee should be updated
   await ledger.mock.lock_transfer("INCREASE_FEE_WITHDRAW_IS_BEING_UNDERWAY_SCENARIO_1");
   transfer_count := await ledger.mock.transfer_count();
-  let f1 = async { await* handler.withdraw(account, 5) };
+  let f1 = async { await* handler.withdrawFromCredit(user1, account, 5) };
   await ledger.mock.set_fee(2);
   await ledger.mock.set_response([#Err(#BadFee { expected_fee = 2 }), #Ok 42]);
   await ledger.mock.release_transfer(); // let transfer return
   assert (await f1) == #ok(42, 3);
   assert (await ledger.mock.transfer_count()) == transfer_count + 2;
-  assert handler.journalLength() == inc(6); // #feeUpdated, #depositFeeUpdated, #withdrawalFeeUpdated, #depositMinimumUpdated, #withdrawalMinimumUpdated, #withdraw
+  assert handler.journalLength() == inc(7); // #burned, #feeUpdated, #depositMinimumUpdated, #withdrawalMinimumUpdated, depositFeeUpdated, withdrawalFeeUpdated, #withdraw
   assert state(handler) == (0, 5, 0); // state has changed
-  handler.debit(user1, 5);
+  assert handler.debitUser(user1, 5);
   assert handler.journalLength() == inc(1); // #debited
 
   // increase fee while withdraw is being underway
@@ -352,14 +354,85 @@ do {
   // the second call should be avoided with comparison amount and fee
   await ledger.mock.lock_transfer("INCREASE_FEE_WITHDRAW_IS_BEING_UNDERWAY_SCENARIO_2");
   transfer_count := await ledger.mock.transfer_count();
-  let f2 = async { await* handler.withdraw(account, 4) };
+  let f2 = async { await* handler.withdrawFromPool(account, 4) };
   await ledger.mock.set_fee(4);
   await ledger.mock.set_response([#Err(#BadFee { expected_fee = 4 }), #Ok 42]); // the second call should not be executed
   await ledger.mock.release_transfer(); // let transfer return
   assert (await f2) == #err(#TooLowQuantity);
   assert (await ledger.mock.transfer_count()) == transfer_count + 1; // the second transfer call is avoided
   assert state(handler) == (0, 5, 0); // state unchanged
-  assert handler.journalLength() == inc(6); // #feeUpdated, #depositFeeUpdated, #withdrawalFeeUpdated, #depositMinimumUpdated, #withdrawalMinimumUpdated, #withdrawalError
+  assert handler.journalLength() == inc(8); // #burned, #feeUpdated, #depositMinimumUpdated, #withdrawalMinimumUpdated, #depositFeeUpdated, #withdrawalFeeUpdated, #withdrawalError, #issued
+
+  handler.assertIntegrity();
+  assert not handler.isFrozen();
+};
+
+do {
+  let handler = TokenHandler.TokenHandler(ledger, anon_p, 1000, 0);
+  await ledger.mock.reset_state();
+  let (inc, _) = create_inc();
+
+  // update fee first time
+  await ledger.mock.set_fee(5);
+  ignore await* handler.fetchFee();
+  assert handler.ledgerFee() == 5;
+  assert handler.fee(#deposit) == 5;
+  assert handler.fee(#withdrawal) == 5;
+  assert handler.journalLength() == inc(5); // #feeUpdated, #depositMinimumUpdated, #withdrawalMinimumUpdated, #depositFeeUpdated, #withdrawalFeeUpdated
+
+  // another user deposit + consolidation
+  await ledger.mock.set_balance(300);
+  assert (await* handler.notify(user2)) == ?(300, 295); // deposit = 300, credit = 295
+  assert handler.journalLength() == inc(2); // #newDeposit, #credited
+  await ledger.mock.set_response([#Ok 42]);
+  await* handler.trigger();
+  await ledger.mock.set_balance(0);
+  assert state(handler) == (0, 295, 0); // consolidation successful
+  assert handler.journalLength() == inc(1); // #consolidated
+  print("tree lookups = " # debug_show handler.lookups_());
+
+  // increase deposit
+  await ledger.mock.set_balance(20);
+  assert (await* handler.notify(user1)) == ?(20, 15); // deposit = 20, credit = 15
+  assert state(handler) == (20, 295, 1);
+  assert handler.journalLength() == inc(2); // #newDeposit, #credited
+  print("tree lookups = " # debug_show handler.lookups_());
+
+  // trigger consolidation
+  await ledger.mock.set_response([#Ok 42]);
+  await* handler.trigger();
+  await ledger.mock.set_balance(0);
+  assert state(handler) == (0, 310, 0); // consolidation successful
+  assert handler.journalLength() == inc(1); // #consolidated
+  print("tree lookups = " # debug_show handler.lookups_());
+
+  // withdraw from credit (fee < amount =< credit)
+  // should be successful
+  await ledger.mock.set_fee(1);
+  ignore await* handler.fetchFee();
+  assert handler.journalLength() == inc(5); // #feeUpdated, #depositMinimumUpdated, #withdrawalMinimumUpdated, #depositFeeUpdated, #withdrawalFeeUpdated
+  await ledger.mock.set_response([#Ok 42]);
+  assert (await* handler.withdrawFromCredit(user1, account, 5)) == #ok(42, 4);
+  assert handler.journalLength() == inc(2); // #withdraw, #debited
+  assert state(handler) == (0, 305, 0);
+  assert handler.userCredit(user1) == 10;
+
+  // withdraw from credit (amount <= fee_ =< credit)
+  var transfer_count = await ledger.mock.transfer_count();
+  await ledger.mock.set_response([#Ok 42]); // transfer call should not be executed anyway
+  assert (await* handler.withdrawFromCredit(user1, account, 1)) == #err(#TooLowQuantity);
+  assert (await ledger.mock.transfer_count()) == transfer_count; // no transfer call
+  assert state(handler) == (0, 305, 0); // state unchanged
+  assert handler.journalLength() == inc(3); // #burned, #withdrawError, #issued
+
+  // withdraw from credit (credit < amount)
+  // insufficient user credit
+  transfer_count := await ledger.mock.transfer_count();
+  await ledger.mock.set_response([#Ok 42]); // transfer call should not be executed anyway
+  assert (await* handler.withdrawFromCredit(user1, account, 12)) == #err(#InsufficientCredit); // amount 12 > credit 10
+  assert (await ledger.mock.transfer_count()) == transfer_count; // no transfer call
+  assert state(handler) == (0, 305, 0); // state unchanged
+  assert handler.journalLength() == inc(1); // #withdrawError
 
   handler.assertIntegrity();
   assert not handler.isFrozen();
@@ -385,14 +458,14 @@ do {
   await ledger.mock.set_balance(0);
   assert state(handler) == (0, 295, 0); // consolidation successful
   assert handler.journalLength() == inc(1); // #consolidated
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // increase deposit
   await ledger.mock.set_balance(20);
   assert (await* handler.notify(user1)) == ?(20, 15); // deposit = 20, credit = 15
   assert state(handler) == (20, 295, 1);
   assert handler.journalLength() == inc(2); // #newDeposit, #credited
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // trigger consolidation
   await ledger.mock.set_response([#Ok 42]);
@@ -400,7 +473,7 @@ do {
   await ledger.mock.set_balance(0);
   assert state(handler) == (0, 310, 0); // consolidation successful
   assert handler.journalLength() == inc(1); // #consolidated
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // withdraw from credit (fee < amount =< credit)
   // should be successful
@@ -411,7 +484,7 @@ do {
   assert (await* handler.withdrawFromCredit(user1, account, 5)) == #ok(42, 4);
   assert handler.journalLength() == inc(2); // #withdraw, #debited
   assert state(handler) == (0, 305, 0);
-  assert handler.getCredit(user1) == 10;
+  assert handler.userCredit(user1) == 10;
 
   // withdraw from credit (amount <= fee_ =< credit)
   var transfer_count = await ledger.mock.transfer_count();
@@ -419,7 +492,7 @@ do {
   assert (await* handler.withdrawFromCredit(user1, account, 1)) == #err(#TooLowQuantity);
   assert (await ledger.mock.transfer_count()) == transfer_count; // no transfer call
   assert state(handler) == (0, 305, 0); // state unchanged
-  assert handler.journalLength() == inc(1); // #withdrawError
+  assert handler.journalLength() == inc(3); // #burned, #withdrawError, #issued
 
   // withdraw from credit (credit < amount)
   // insufficient user credit
@@ -459,9 +532,9 @@ do {
   await ledger.mock.release_balance(); // let notify return
   assert (await f1) == ?(0, 0);
   assert state(handler) == (0, 0, 0); // state unchanged because deposit has not changed
-  assert handler.getCredit(user1) == 0; // credit should not be corrected
+  assert handler.userCredit(user1) == 0; // credit should not be corrected
   assert handler.journalLength() == inc(0);
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // scenario 2: decrease fee
   await ledger.mock.lock_balance("CHANGE_FEE_WHILE_NOTIFY_IS_UNDERWAY_WITH_LOCKED_0_DEPOSIT_SCENARIO_2");
@@ -473,33 +546,34 @@ do {
   await ledger.mock.release_balance(); // let notify return
   assert (await f2) == ?(5, 3);
   assert state(handler) == (5, 0, 1); // state unchanged because deposit has not changed
-  assert handler.getCredit(user1) == 3; // credit should not be corrected
+  assert handler.userCredit(user1) == 3; // credit should not be corrected
   assert handler.journalLength() == inc(2); // #credited, #newDeposit
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // Recalculate credits related to deposits when fee changes
 
   // scenario 1: new_fee < prev_fee < deposit
   await ledger.mock.set_fee(1);
   ignore await* handler.fetchFee();
-  assert handler.journalLength() == inc(6); // #feeUpdated, #depositFeeUpdated, #withdrawalFeeUpdated, #credited, #depositMinimumUpdated, #withdrawalMinimumUpdated
-  assert handler.getCredit(user1) == 4; // credit corrected
+  assert handler.journalLength() == inc(6); // #feeUpdated, #credited, #depositMinimumUpdated, #withdrawalMinimumUpdated, #depositFeeUpdated, #withdrawalFeeUpdated
+  assert handler.userCredit(user1) == 4; // credit corrected
 
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // scenario 2: prev_fee < new_fee < deposit
   await ledger.mock.set_fee(3);
   ignore await* handler.fetchFee();
-  assert handler.journalLength() == inc(6); // #feeUpdated, #depositFeeUpdated, #withdrawalFeeUpdated, #debited, #depositMinimumUpdated, #withdrawalMinimumUpdated
-  assert handler.getCredit(user1) == 2; // credit corrected
-  print("tree lookups = " # debug_show handler.lookups());
+  assert handler.journalLength() == inc(6); // #feeUpdated, #debited, #depositMinimumUpdated, #withdrawalMinimumUpdated, #depositFeeUpdated, #withdrawalFeeUpdated
+  assert handler.userCredit(user1) == 2; // credit corrected
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // scenario 3: prev_fee < deposit <= new_fee
   await ledger.mock.set_fee(5);
   ignore await* handler.fetchFee();
-  assert handler.journalLength() == inc(6); // #feeUpdated, #depositFeeUpdated, #withdrawalFeeUpdated, #debited, #depositMinimumUpdated, #withdrawalMinimumUpdated
-  assert handler.getCredit(user1) == 0; // credit corrected
-  print("tree lookups = " # debug_show handler.lookups());
+  // TODO assert handler.journalLength() == inc(6); // #feeUpdated, #depositFeeUpdated, #withdrawalFeeUpdated, #debited, #depositMinimumUpdated, #withdrawalMinimumUpdated
+  assert handler.journalLength() == inc(6); // #feeUpdated, #debited, #depositMinimumUpdated, #withdrawalMinimumUpdated, #depositFeeUpdated, #withdrawalFeeUpdated
+  assert handler.userCredit(user1) == 0; // credit corrected
+  print("tree lookups = " # debug_show handler.lookups_());
 
   handler.assertIntegrity();
   assert not handler.isFrozen();
@@ -514,8 +588,8 @@ do {
   await ledger.mock.set_fee(5);
   ignore await* handler.fetchFee();
   assert handler.ledgerFee() == 5;
-  assert handler.journalLength() == inc(5); // #feeUpdated, #depositFeeUpdated, #withdrawalFeeUpdated, #depositMinimumUpdated, #withdrawalMinimumUpdated
-  print("tree lookups = " # debug_show handler.lookups());
+  assert handler.journalLength() == inc(5); // #feeUpdated, #depositMinimumUpdated, #withdrawalMinimumUpdated, #depositFeeUpdated, #withdrawalFeeUpdated
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // fetching fee should not overlap
   await ledger.mock.lock_fee("FETCHING_FEE_SHOULD_NOT_OVERLAP");
@@ -525,8 +599,8 @@ do {
   assert (await f2) == null;
   await ledger.mock.release_fee();
   assert (await f1) == ?6;
-  assert handler.journalLength() == inc(5); // #feeUpdated, #depositFeeUpdated, #withdrawalFeeUpdated, #depositMinimumUpdated, #withdrawalMinimumUpdated
-  print("tree lookups = " # debug_show handler.lookups());
+  assert handler.journalLength() == inc(5); // #feeUpdated, #depositMinimumUpdated, #withdrawalMinimumUpdated, #depositFeeUpdated, #withdrawalFeeUpdated
+  print("tree lookups = " # debug_show handler.lookups_());
 
   handler.assertIntegrity();
   assert not handler.isFrozen();
@@ -543,8 +617,8 @@ do {
   assert handler.ledgerFee() == 5;
   assert handler.minimum(#deposit) == 6;
   assert handler.minimum(#withdrawal) == 6;
-  assert handler.journalLength() == inc(5); // #feeUpdated, #depositFeeUpdated, #withdrawalFeeUpdated, #depositMinimumUpdated, #withdrawalMinimumUpdated
-  print("tree lookups = " # debug_show handler.lookups());
+  assert handler.journalLength() == inc(5); // #feeUpdated, #depositMinimumUpdated, #withdrawalMinimumUpdated, #depositFeeUpdated, #withdrawalFeeUpdated
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // set deposit minimum
   // case: min > fee
@@ -557,21 +631,21 @@ do {
   handler.setMinimum(#deposit, 12);
   assert handler.minimum(#deposit) == 12;
   assert handler.journalLength() == inc(0);
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // set deposit minimum
   // case: min < fee
   handler.setMinimum(#deposit, 4);
   assert handler.minimum(#deposit) == 6; // fee + 1
   assert handler.journalLength() == inc(1); // #depositMinimumUpdated
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // set deposit minimum
   // case: min == fee
   handler.setMinimum(#deposit, 5);
   assert handler.minimum(#deposit) == 6;
   assert handler.journalLength() == inc(0);
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // notify
   // case: fee < balance < min
@@ -581,14 +655,14 @@ do {
   await ledger.mock.set_balance(8);
   assert (await* handler.notify(user1)) == ?(0, 0);
   assert handler.journalLength() == inc(0);
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // notify
   // case: fee < min <= balance
   await ledger.mock.set_balance(9);
   assert (await* handler.notify(user1)) == ?(9, 4);
   assert handler.journalLength() == inc(2); // #credited, #newDeposit
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // notify
   // case: fee < balance < min, old deposit exists
@@ -599,7 +673,7 @@ do {
   await ledger.mock.set_balance(12);
   assert (await* handler.notify(user1)) == ?(0, 4); // deposit not updated
   assert handler.journalLength() == inc(0);
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   handler.assertIntegrity();
   assert not handler.isFrozen();
@@ -623,7 +697,7 @@ do {
   assert (await* handler.notify(user1)) == ?(20, 15); // deposit = 20, credit = 15
   assert state(handler) == (20, 0, 1);
   assert handler.journalLength() == inc(2); // #newDeposit, #credited
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // trigger consolidation again
   await ledger.mock.set_response([#Ok 42]);
@@ -631,7 +705,7 @@ do {
   await ledger.mock.set_balance(0);
   assert state(handler) == (0, 15, 0); // consolidation successful
   assert handler.journalLength() == inc(1); // #consolidated
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // set withdrawal minimum
   // case: min > fee
@@ -644,21 +718,21 @@ do {
   handler.setMinimum(#withdrawal, 12);
   assert handler.minimum(#withdrawal) == 12;
   assert handler.journalLength() == inc(0);
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // set withdrawal minimum
   // case: min < fee
   handler.setMinimum(#withdrawal, 4);
   assert handler.minimum(#withdrawal) == 6; // fee + 1
   assert handler.journalLength() == inc(1); // #depositMinimumUpdated
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // set withdrawal minimum
   // case: min == fee
   handler.setMinimum(#withdrawal, 5);
   assert handler.minimum(#withdrawal) == 6;
   assert handler.journalLength() == inc(0);
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // increase withdrawal minimum
   handler.setMinimum(#withdrawal, 11);
@@ -669,20 +743,67 @@ do {
   // case: fee < amount < min
   var transfer_count = await ledger.mock.transfer_count();
   await ledger.mock.set_response([#Ok 42]); // transfer call should not be executed anyway
-  assert (await* handler.withdraw(account, 6)) == #err(#TooLowQuantity);
+  assert (await* handler.withdrawFromCredit(user1, account, 6)) == #err(#TooLowQuantity);
   assert (await ledger.mock.transfer_count()) == transfer_count; // no transfer call
   assert state(handler) == (0, 15, 0); // state unchanged
-  assert handler.journalLength() == inc(1); // #withdrawError
-  print("tree lookups = " # debug_show handler.lookups());
+  assert handler.journalLength() == inc(3); // #burned, #withdrawError, #issued
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // withdraw
   // case: fee < min <= amount
   await ledger.mock.set_response([#Ok 42]);
-  assert (await* handler.withdraw(account, 11)) == #ok(42, 6);
-  assert handler.journalLength() == inc(1); // #withdraw
-  handler.debit(user1, 11);
+  assert (await* handler.withdrawFromCredit(user1, account, 11)) == #ok(42, 6);
+  assert handler.journalLength() == inc(2); // #burned, #withdraw
   assert state(handler) == (0, 4, 0);
+
+  handler.assertIntegrity();
+  assert not handler.isFrozen();
+};
+
+do {
+  let handler = TokenHandler.TokenHandler(ledger, anon_p, 1000, 0);
+  await ledger.mock.reset_state();
+  let (inc, _) = create_inc();
+
+//  TODO: fix tests
+
+  // credit issuer
+  handler.issue_(#pool, 20);
+  assert handler.poolCredit() == 20;
+  assert handler.journalLength() == inc(1); // #issued
+
+  // debit issuer
+  handler.issue_(#pool, -5);
+  assert handler.poolCredit() == 15;
+  assert handler.journalLength() == inc(1); // #issued
+
+  // credit user
+  // case: pool credit < amount
+  assert (handler.creditUser(user1, 30)) == false;
+  assert handler.journalLength() == inc(0);
+  assert handler.poolCredit() == 15;
+  assert handler.userCredit(user1) == 0;
+
+  // credit user
+  // case: pool credit <= amount
+  assert (handler.creditUser(user1, 15)) == true;
+  assert handler.journalLength() == inc(1); // #credited
+  assert handler.poolCredit() == 0;
+  assert handler.userCredit(user1) == 15;
+
+  // debit user
+  // case: credit < amount
+  assert (handler.debitUser(user1, 16)) == false;
+  assert handler.journalLength() == inc(0);
+  assert handler.poolCredit() == 0;
+  assert handler.userCredit(user1) == 15;
+
+  // debit user
+  // case: credit >= amount
+  assert (handler.debitUser(user1, 15)) == true;
   assert handler.journalLength() == inc(1); // #debited
+  assert handler.poolCredit() == 15;
+  assert handler.userCredit(user1) == 0;
 
   handler.assertIntegrity();
   assert not handler.isFrozen();
@@ -731,11 +852,11 @@ do {
   assert handler.journalLength() == inc(2); // #credited, #newDeposit
 
   // set deposit fee (new_min) > balance
-  assert handler.getCredit(user1) == 8;
+  assert handler.userCredit(user1) == 8;
   handler.setFee(#deposit, 6);
   assert handler.fee(#deposit) == 6;
   assert handler.journalLength() == inc(3); // #depositFeeUpdated, #depositMinimumUpdated, #debited
-  assert handler.getCredit(user1) == 7; // credit corrected
+  assert handler.userCredit(user1) == 7; // credit corrected
 
   // trigger consolidation
   await ledger.mock.set_response([#Ok 42]);
@@ -780,7 +901,7 @@ do {
   assert (await* handler.withdrawFromCredit(user1, account, 5)) == #ok(42, 1);
   assert handler.journalLength() == inc(2); // #withdraw, #debited
   assert state(handler) == (0, 2, 0);
-  assert handler.getCredit(user1) == 2;
+  assert handler.userCredit(user1) == 2;
 
   handler.assertIntegrity();
   assert not handler.isFrozen();
@@ -792,42 +913,42 @@ do {
   let (inc, _) = create_inc();
 
   // credit issuer
-  handler.creditIssuer(20);
-  assert handler.issuer() == 20;
-  assert handler.journalLength() == inc(1); // #issuerCredited
+  handler.issue_(#pool, 20);
+  assert handler.poolCredit() == 20;
+  assert handler.journalLength() == inc(1); // #issued
 
   // debit issuer
-  handler.debitIssuer(5);
-  assert handler.issuer() == 15;
-  assert handler.journalLength() == inc(1); // #issuerCredited
+  handler.issue_(#pool, -5);
+  assert handler.poolCredit() == 15;
+  assert handler.journalLength() == inc(1); // #issued
 
   // credit (strict)
   // case: issuer_credit < amount
-  assert (handler.creditStrict(user1, 30)) == false;
+  assert (handler.creditUser(user1, 30)) == false;
   assert handler.journalLength() == inc(0);
-  assert handler.issuer() == 15;
-  assert handler.getCredit(user1) == 0;
+  assert handler.poolCredit() == 15;
+  assert handler.userCredit(user1) == 0;
 
   // credit (strict)
   // case: issuer_credit <= amount
-  assert (handler.creditStrict(user1, 15)) == true;
-  assert handler.journalLength() == inc(2); // #credited, #issuerDebited
-  assert handler.issuer() == 0;
-  assert handler.getCredit(user1) == 15;
+  assert (handler.creditUser(user1, 15)) == true;
+  assert handler.journalLength() == inc(1); // #credited
+  assert handler.poolCredit() == 0;
+  assert handler.userCredit(user1) == 15;
 
   // debit (strict)
   // case: credit < amount
-  assert (handler.debitStrict(user1, 16)) == false;
+  assert (handler.debitUser(user1, 16)) == false;
   assert handler.journalLength() == inc(0);
-  assert handler.issuer() == 0;
-  assert handler.getCredit(user1) == 15;
+  assert handler.poolCredit() == 0;
+  assert handler.userCredit(user1) == 15;
 
   // debit (strict)
   // case: credit >= amount
-  assert (handler.debitStrict(user1, 15)) == true;
-  assert handler.journalLength() == inc(2); // #debited, #issuerCredited
-  assert handler.issuer() == 15;
-  assert handler.getCredit(user1) == 0;
+  assert (handler.debitUser(user1, 15)) == true;
+  assert handler.journalLength() == inc(1); // #debited
+  assert handler.poolCredit() == 15;
+  assert handler.userCredit(user1) == 0;
 
   handler.assertIntegrity();
   assert not handler.isFrozen();
@@ -851,25 +972,25 @@ do {
   assert (await* handler.depositFromAllowance(user1_account, 9)) == #err(#InsufficientAllowance({ allowance = 8 }));
   assert state(handler) == (0, 0, 0);
   assert handler.journalLength() == inc(1); // #consolidationError
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // deposit from allowance >= amount
   await ledger.mock.set_transfer_from_res([#Ok 42]);
   assert (await* handler.depositFromAllowance(user1_account, 8)) == #ok(3);
-  assert handler.getCredit(user1) == 3;
+  assert handler.userCredit(user1) == 3;
   assert state(handler) == (0, 3, 0);
   assert handler.journalLength() == inc(3); // #consolidated, #newDeposit, #credited
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // deposit from allowance < minimum
   await ledger.mock.set_transfer_from_res([#Ok 42]); // should be not called
   var transfer_from_count = await ledger.mock.transfer_from_count();
   assert (await* handler.depositFromAllowance(user1_account, 5)) == #err(#TooLowQuantity);
-  assert handler.getCredit(user1) == 3; // not changed
+  assert handler.userCredit(user1) == 3; // not changed
   assert state(handler) == (0, 3, 0); // not changed
   assert transfer_from_count == (await ledger.mock.transfer_from_count());
   assert handler.journalLength() == inc(0);
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // ledger fee is increased while deposit from allowance is underway
   // old_fee < new_fee < amount
@@ -880,14 +1001,14 @@ do {
   await ledger.mock.set_transfer_from_res([#Err(#BadFee { expected_fee = 6 }), #Ok 42]);
   await ledger.mock.release_transfer_from();
   assert (await f1) == #ok(2);
-  assert handler.getCredit(user1) == 5;
+  assert handler.userCredit(user1) == 5;
   assert state(handler) == (0, 5, 0);
   assert transfer_from_count + 2 == (await ledger.mock.transfer_from_count());
   // #feeUpdated, #depositMinimumUpdated, #withdrawalMinimumUpdated
   // #depositFeeUpdated, #withdrawalFeeUpdated, #consolidated
   // #newDeposit, #credited
   assert handler.journalLength() == inc(8);
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // ledger fee is increased while deposit from allowance is underway
   // old_fee < amount < new_fee
@@ -898,13 +1019,13 @@ do {
   await ledger.mock.set_transfer_from_res([#Err(#BadFee { expected_fee = 9 })]);
   await ledger.mock.release_transfer_from();
   assert (await f2) == #err(#TooLowQuantity);
-  assert handler.getCredit(user1) == 5; // unchanged
+  assert handler.userCredit(user1) == 5; // unchanged
   assert state(handler) == (0, 5, 0); // unchanged
   assert transfer_from_count + 1 == (await ledger.mock.transfer_from_count());
   // #feeUpdated, #depositMinimumUpdated, #withdrawalMinimumUpdated
   // #depositFeeUpdated, #withdrawalFeeUpdated, #consolidationError
   assert handler.journalLength() == inc(6);
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // ledger fee is decreased while deposit from allowance is underway
   // new_fee < old_fee < amount
@@ -915,14 +1036,14 @@ do {
   await ledger.mock.set_transfer_from_res([#Err(#BadFee { expected_fee = 8 }), #Ok 42]);
   await ledger.mock.release_transfer_from();
   assert (await f3) == #ok(1); // amount - old_fee
-  assert handler.getCredit(user1) == 6;
+  assert handler.userCredit(user1) == 6;
   assert state(handler) == (0, 6, 0);
   assert transfer_from_count + 2 == (await ledger.mock.transfer_from_count());
   // #feeUpdated, #depositMinimumUpdated, #withdrawalMinimumUpdated
   // #depositFeeUpdated, #withdrawalFeeUpdated, #consolidated
   // #newDeposit, #credited
   assert handler.journalLength() == inc(8);
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   handler.assertIntegrity();
   assert not handler.isFrozen();
@@ -942,21 +1063,21 @@ do {
   // notify with 0 balance
   await ledger.mock.set_balance(0);
   assert (await* handler.notify(user1)) == ?(0, 0);
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // pause notifications
   handler.pauseNotifications();
 
   // notify with 0 balance
   assert (await* handler.notify(user1)) == null;
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   // unpause notifications
   handler.unpauseNotifications();
 
   // notify with 0 balance
   assert (await* handler.notify(user1)) == ?(0, 0);
-  print("tree lookups = " # debug_show handler.lookups());
+  print("tree lookups = " # debug_show handler.lookups_());
 
   handler.assertIntegrity();
   assert not handler.isFrozen();


### PR DESCRIPTION
New concepts:
- issuer is now called pool
- the terms credit/debit now mean transfer between user and pool, they don't mean issuing new credit
- the term issue means to issue new credit from thin air, either to a user or to the pool
- the term issue more generally means any change to the credit supply, also negative (aka burning)

As a consequence:
- credit/debit is always strict, balances cannot go negative
- issue is not strict

Specific functions:
- creditUser, debitUser: transfer functions between user credit and pool

Withdraw functions are now:
- withdrawFromPool
- withdrawFromCredit

There is no general "withdraw" function anymore. It is replaced by withdrawFromPool.